### PR TITLE
Threat Intelligence Objects (QAI-1138)

### DIFF
--- a/query/dictionary.json
+++ b/query/dictionary.json
@@ -23,6 +23,33 @@
       "caption": "Sender Users",
       "description": "The user who sent the email",
       "type": "user"
-    }
+    },
+		"reputations": {
+			"caption": "Reputations",
+			"description": "Reputation score as reported by provider",
+			"is_array": true,
+			"type": "reputation" 
+		},
+		"findings": {
+			"caption": "Findings",
+			"description": "The findings from threat intelligence platforms",
+			"type": "finding",
+			"is_array": true
+		},
+		"filenames": {
+			"description": "The names a file is known by.",
+			"type": "string_t",
+			"is_array": true
+		},
+		"asn": {
+			"description": "The 2- or 4-byte Autonomous System Number (ASN)",
+			"type": "integer_t",
+			"caption": "ASN"
+		},
+		"as_owner": {
+			"description": "The Autonomous System (AS) owner",
+			"type": "string_t",
+			"caption": "AS Owner"
+		}
   }
 }

--- a/query/dictionary.json
+++ b/query/dictionary.json
@@ -46,7 +46,7 @@
 			"type": "integer_t",
 			"caption": "ASN"
 		},
-		"as_owner": {
+		"asn_owner": {
 			"description": "The Autonomous System (AS) owner",
 			"type": "string_t",
 			"caption": "AS Owner"

--- a/query/objects/domain_intelligence.json
+++ b/query/objects/domain_intelligence.json
@@ -1,0 +1,40 @@
+{
+	"description": "Insights from threat intelligence platforms about domains",
+	"caption": "Domain Threat Intelligence",
+	"name": "domain_intelligence",
+	"attributes": {
+		"domain": {
+			"requirement": "optional"
+		},
+		"domain_info": {
+			"requirement": "optional"
+		},
+		"answers": {
+			"requirement": "optional"
+		},
+		"labels": {
+			"description": "The labels or tags in the intelligence.",
+			"requirement": "optional"
+		},
+		"reputations": {
+			"description": "Reputation score as reported by provider",
+			"requirement": "optional"
+		},
+		"details": {
+			"description": "Details about the domain.",
+			"requirement": "optional"
+		},
+		"vendor_name": {
+			"description": "The vendor that provided the intelligence.",
+			"requirement": "optional"
+		},
+		"findings": {
+			"description": "The findings from threat intelligence platforms",
+			"requirement": "optional"
+		},
+		"references": {
+			"caption": "Additional references for more information.",
+			"requirement": "optional"
+		}
+	}
+}

--- a/query/objects/file_intelligence.json
+++ b/query/objects/file_intelligence.json
@@ -1,0 +1,45 @@
+{
+	"description": "Insights from threat intelligence platforms about files",
+	"caption": "File Threat Intelligence",
+	"name": "file_intelligence",
+	"attributes": {
+		"fingerprints": {
+			"description": "An array of known fingerprints for the file.",
+			"requirement": "optional"
+		},
+		"filenames": {
+			"description": "The names a file is known by.",
+			"requirement": "optional"
+		},
+		"details": {
+			"description": "Details about the file.",
+			"requirement": "optional"
+		},
+		"vendor_name": {
+			"description": "The vendor that provided the intelligence.",
+			"requirement": "optional"
+		},
+		"reputations": {
+			"description": "Reputation score as reported by provider",
+			"requirement": "optional"
+		},
+		"findings": {
+			"description": "The findings from threat intelligence platforms",
+			"requirement": "optional"
+		},
+		"labels": {
+			"description": "The labels or tags in the intelligence.",
+			"requirement": "optional"
+		},
+		"first_seen_time": {
+			"requirement": "optional"
+		},
+		"last_seen_time": {
+			"requirement": "optional"
+		},
+		"references": {
+			"caption": "Additional references for more information.",
+			"requirement": "optional"
+		}
+	}
+}

--- a/query/objects/ip_intelligence.json
+++ b/query/objects/ip_intelligence.json
@@ -24,7 +24,7 @@
 		"asn": {
 			"requirement": "optional"
 		},
-		"as_owner": {
+		"asn_owner": {
 			"requirement": "optional"
 		},
 		"details": {

--- a/query/objects/ip_intelligence.json
+++ b/query/objects/ip_intelligence.json
@@ -1,0 +1,47 @@
+{
+	"description": "Insights from threat intelligence platforms about IP Addresses",
+	"caption": "IP Threat Intelligence",
+	"name": "ip_intelligence",
+	"attributes": {
+
+		"labels": {
+			"description": "The labels or tags in the intelligence.",
+			"requirement": "optional"
+		},
+		"reputations": {
+			"description": "Reputation score as reported by provider",
+			"requirement": "optional"
+		},
+		"location": {
+			"requirement": "optional"
+		},
+		"ip": {
+			"requirement": "optional"
+		},
+		"subnet": {
+			"requirement": "optional"
+		},
+		"asn": {
+			"requirement": "optional"
+		},
+		"as_owner": {
+			"requirement": "optional"
+		},
+		"details": {
+			"description": "Details about the IP address.",
+			"requirement": "optional"
+		},
+		"vendor_name": {
+			"description": "The vendor that provided the intelligence.",
+			"requirement": "optional"
+		},
+		"findings": {
+			"description": "The findings from threat intelligence platforms",
+			"requirement": "optional"
+		},
+		"references": {
+			"caption": "Additional references for more information.",
+			"requirement": "optional"
+		}
+	}
+}

--- a/query/objects/url_intelligence.json
+++ b/query/objects/url_intelligence.json
@@ -1,0 +1,39 @@
+{
+	"description": "Insights from threat intelligence platforms about URLs",
+	"caption": "URL Threat Intelligence",
+	"name": "url_intelligence",
+	"attributes": {
+		"url": {
+			"description": "The URL the intelligence applies to.",
+			"requirement": "optional"
+		},
+		"categories": {
+			"requirement": "optional"
+		},
+		"category_ids": {
+			"requirement": "optional"
+		},
+		"vendor_name": {
+			"description": "The vendor that provided the intelligence.",
+			"requirement": "optional"
+		},
+		"reputations": {
+			"description": "Reputation score as reported by provider",
+			"requirement": "optional"
+		},
+		"findings": {
+			"description": "The findings from threat intelligence platforms",
+			"requirement": "optional"
+		},
+		"labels": {
+			"description": "The labels or tags in the intelligence.",
+			"requirement": "optional"
+		},
+		"first_seen_time": {
+			"requirement": "optional"
+		},
+		"last_seen_time": {
+			"requirement": "optional"
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces four new objects to contain threat intelligence for files, domains, IPs, and URLs.

This PR is based from our latest stable tag to sidestep unintended changes (some of which are invalid!) that have been pulled into our schema fork since our last stable tag.