### PR TITLE
Adding full_name and last_login_time to user

### DIFF
--- a/query/dictionary.json
+++ b/query/dictionary.json
@@ -50,6 +50,16 @@
 			"description": "The Autonomous System (AS) owner",
 			"type": "string_t",
 			"caption": "AS Owner"
-		}
+		},
+	"full_name": {
+      "caption": "Full Name",
+      "description": "The full name of the person, as per the LDAP Common Name attribute (cn).",
+      "type": "string_t"
+    },
+    "last_login_time": {
+      "caption": "Last Login",
+      "description": "The last time when the user logged in.",
+      "type": "timestamp_t"
+    }
   }
 }

--- a/query/objects/user.json
+++ b/query/objects/user.json
@@ -8,6 +8,12 @@
     "devices": {
       "description": "The devices related to user.",
       "requirement": "optional"
-    }
+    },
+	"full_name": {
+		"requirement": "optional"
+	},
+	"last_login_time": {
+		"requirement": "optional"
+	}
   }
 }


### PR DESCRIPTION
# What
Adding a `full_name` property to user as well as a `last_login_time`.

# Why?
Every† identity platform we've integrated with stores the user's real name. We forked from OCSF early, and this was missing from the user object. Later versions added a person profile with `full_name`, and then merged the contents of that profile into user. Users in OCSF 1.0 have a `full_name` property, so this is a future proof change.

I've also added a `last_login_time` because it's relevant security information. It's in Okta, Auth0, and AD and we get asked to add it every time we add an identity driver. `last_login_time` exists in OCSF 1.0's `dictionary.json` but doesn't appear to be used.


_† At least I'm pretty sure_