### PR TITLE
Update extends attribute in sec finding in query namespace

### DIFF
--- a/query/events/findings/security_finding.json
+++ b/query/events/findings/security_finding.json
@@ -2,7 +2,7 @@
   "caption": "Security Finding",
   "category": "findings",
   "description": "Security Finding events describe findings, detections, anomalies, alerts and/or actions performed by security products",
-  "extends": "findings",
+  "extends": [null, "security_finding"],
   "name": "security_finding",
   "attributes": {
 		"device": {


### PR DESCRIPTION
#### Related Issue: 

device was added as a related attribute in security_finding in query namespace but was but was getting ignored by codegen

#### Description of changes:

All query namespace events and objects should have extends attribute as a list having two elements. The first element is name of the namespace in ocsf i.e. null, dev, etc and second element points to the name of the object/event in the namespace which we want to extend

