### PR TITLE
Qai 1447: Add ip_intelligence related attribute to network endpoint

### DIFF
--- a/query/dictionary.json
+++ b/query/dictionary.json
@@ -62,6 +62,11 @@
       "description": "The full name of the person, as per the LDAP Common Name attribute (cn).",
       "type": "string_t"
     },
+    "ip_intelligence": {
+      "caption": "IP Intelligence",
+      "description": "Insights from threat intelligence platforms about IP Address",
+      "type": "ip_intelligence"
+    },
     "last_login_time": {
       "caption": "Last Login",
       "description": "The last time when the user logged in.",

--- a/query/objects/network_endpoint.json
+++ b/query/objects/network_endpoint.json
@@ -1,0 +1,12 @@
+{
+  "caption": "Network Endpoint",
+  "name": "network_endpoint",
+  "extends": [null, "network_endpoint"],
+  "observable": 0,
+  "description": "The network endpoint object describes source or destination of a network connection.",
+  "attributes": {
+    "ip_intelligence": {
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
Added `ip_intelligence` attribute of type `ip_intelligence` in query extension of `network_endpoint` object

This is an additive change which does not impact existing `ip` attribute in network_endpoint. 