### PR TITLE
QAI-1783: Unmapped schema definition

### DIFF
--- a/extensions/query/dictionary.json
+++ b/extensions/query/dictionary.json
@@ -71,6 +71,16 @@
       "caption": "Last Login",
       "description": "The last time when the user logged in.",
       "type": "timestamp_t"
-    }
+    },
+	"is_array": {
+		"requirement": "optional",
+		"type": "boolean_t",
+		"caption": "Is Array",
+		"description": "If true, the value is understood to be an array. Otherwise it is assumed to be a scalar."
+	},
+	"unmapped": {
+		"type": "unmapped",
+		"is_array": true
+	}
   }
 }

--- a/extensions/query/objects/object.json
+++ b/extensions/query/objects/object.json
@@ -11,6 +11,7 @@
       "description": "Unique identifier for the object",
       "group": "primary",
       "requirement": "required"
-    }
+    },
+	"unmapped": { } 
   }
 }

--- a/extensions/query/objects/unmapped.json
+++ b/extensions/query/objects/unmapped.json
@@ -1,0 +1,27 @@
+{
+	"name": "unmapped",
+	"caption": "Unmapped",
+	"description": "The Unmapped object contains an unmapped datum along with a label and type.",
+	"attributes": {
+		"type": {
+			"requirement": "required",
+			"description": "The type of data that is unmapped."
+		},
+		"name": {
+			"requirement": "required",
+			"description": "The name of the unmapped attribute. This usually corresponds to a field name in the data provider. If no caption is provided, name will be used as a caption. The name attribute must be unique across all unmapped attributes of a record."
+		},
+		"value": {
+			"requirement": "required",
+			"description": "The unmapped attribute value.",
+			"type": "json_t"
+		},
+		"caption": {
+			"requirement": "optional",
+			"description": "A short description or label for the unmapped attribute."
+		},
+		"is_array": {
+			"requirement": "optional"
+		}
+	}
+}


### PR DESCRIPTION
### What?

This PR adds a new `unmapped` object. This object has `value`, `name`, `type`, and optional `caption` and `is_array` properties. It represents a datum that cannot be mapped to the schema as well as information necessary to present the datum.

It also changes the type of `unmapped` in the attribute dictionary so that all `unmapped` attributes use this type, and adds an `unmapped` attribute to nearly all objects (but not to itself).

See [QEP-001](https://docs.google.com/document/d/19BQP56xDORz8xI5KeO6qJaw007EhdC-rfHRI4Rbg7mM/edit?usp=sharing) for more information.