### PR TITLE
Fixing erroneously deprecated network_endpoint object

### DIFF
--- a/extensions/query/objects/network_endpoint.json
+++ b/extensions/query/objects/network_endpoint.json
@@ -3,10 +3,6 @@
   "name": "network_endpoint",
   "extends": "network_endpoint",
   "description": "The network endpoint object describes source or destination of a network connection.",
-	"@deprecated": {
-		"since": "1.4.0",
-		"message": "Deprecated in QDM 1.4.0"
-	},
   "attributes": {
     "ip_intelligence": {
       "requirement": "optional"


### PR DESCRIPTION
At some point, `qdm-curator` erroneously marked `network_endpoint` as being deprecated. Whoops!