### PR TITLE
Adding evidences to findings for QAI-2948

### DIFF
--- a/extensions/query/events/findings/incident_finding.json
+++ b/extensions/query/events/findings/incident_finding.json
@@ -1,0 +1,11 @@
+{
+  "caption": "Incident Finding",
+  "extends": "incident_finding",
+  "name": "incident_finding",
+  "attributes": {
+    "evidences": {
+      "description": "Evidence of the incident finding.",
+      "requirement": "recommended"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `evidences` to `incident_finding` for Crowdstrike mappings.